### PR TITLE
Fixed default value of variable and issues #2

### DIFF
--- a/gpu/bellman.cu
+++ b/gpu/bellman.cu
@@ -102,7 +102,8 @@ int runBellmanFordOnGPU(const char *file, int blockSize, int debug) {
     //But in the case of DIMACS vertex start from 1. so in the relax kernel index of the destination vertex is needed to update the D array.
     //E.size() - because we need to replace each E[i] with its index of V[i]
     //0, V.size()-1 - for binary search of V array with each E[i] to find index
-    updateIndexOfEdges<<<BLOCKS, BLOCK_SIZE>>>(E.size(), d_in_V, d_in_E, 0, V.size()-1);
+    INIT_BLOCKS = (E.size() + BLOCK_SIZE - 1) / BLOCK_SIZE;
+    updateIndexOfEdges<<<INIT_BLOCKS, BLOCK_SIZE>>>(E.size(), d_in_V, d_in_E, 0, V.size()-1);
 
     // Bellman ford
     for (int round = 1; round < V.size(); round++) {

--- a/gpu/bellman.cu
+++ b/gpu/bellman.cu
@@ -73,7 +73,6 @@ int runBellmanFordOnGPU(const char *file, int blockSize, int debug) {
     int *d_out_D; // Final shortest distance
     int *d_out_Di; // Used in keep track of the distance during one single execution of the kernel
     int *d_out_P; // Final parent
-    int *d_out_Pi; // Used in keep track of the parent during one single execution of the kernel
 
     //allocate memory
     cudaMalloc((void**) &d_in_V, V.size() *sizeof(int));
@@ -84,7 +83,6 @@ int runBellmanFordOnGPU(const char *file, int blockSize, int debug) {
     cudaMalloc((void**) &d_out_D, V.size() *sizeof(int));
     cudaMalloc((void**) &d_out_Di, V.size() *sizeof(int));
     cudaMalloc((void**) &d_out_P, V.size() *sizeof(int));
-    cudaMalloc((void**) &d_out_Pi, V.size() *sizeof(int));
 
     //copy to device memory
     cudaMemcpy(d_in_V, V.data(), V.size() *sizeof(int), cudaMemcpyHostToDevice);
@@ -94,9 +92,8 @@ int runBellmanFordOnGPU(const char *file, int blockSize, int debug) {
 
     int INIT_BLOCKS = (V.size() + BLOCK_SIZE - 1) / BLOCK_SIZE;
     initializeArray<<<INIT_BLOCKS, BLOCK_SIZE>>>(V.size(), d_out_D, MAX_VAL, true, 0, 0);
-    initializeArray<<<INIT_BLOCKS, BLOCK_SIZE>>>(V.size(), d_out_P, -1, true, 0, 0);
+    initializeArray<<<INIT_BLOCKS, BLOCK_SIZE>>>(V.size(), d_out_P, MAX_VAL, true, 0, 0);
     initializeArray<<<INIT_BLOCKS, BLOCK_SIZE>>>(V.size(), d_out_Di, MAX_VAL, true, 0, 0);
-    initializeArray<<<INIT_BLOCKS, BLOCK_SIZE>>>(V.size(), d_out_Pi, -1, true, 0, 0);
 
     //Do binary search to find index of each element in E. This won't be necessary if the vertex starts from 0.
     //But in the case of DIMACS vertex start from 1. so in the relax kernel index of the destination vertex is needed to update the D array.
@@ -110,9 +107,10 @@ int runBellmanFordOnGPU(const char *file, int blockSize, int debug) {
         if(DEBUG){
             cout<< "***** round = " << round << " ******* " << endl;
         }
-        relax<<<BLOCKS, BLOCK_SIZE>>>(N, MAX_VAL, d_in_V, d_in_I, d_in_E, d_in_W, d_out_D, d_out_Di, d_out_P, d_out_Pi);
-        updateDistance<<<BLOCKS, BLOCK_SIZE>>>(V.size(), d_in_V, d_in_I, d_in_E, d_in_W, d_out_D, d_out_Di, d_out_P, d_out_Pi);
+        relax<<<BLOCKS, BLOCK_SIZE>>>(N, MAX_VAL, d_in_V, d_in_I, d_in_E, d_in_W, d_out_D, d_out_Di);
+        updateDistance<<<BLOCKS, BLOCK_SIZE>>>(V.size(), d_in_V, d_in_I, d_in_E, d_in_W, d_out_D, d_out_Di);
     }
+    updatePred<<<BLOCKS, BLOCK_SIZE>>> (V.size(), d_in_V, d_in_I, d_in_E, d_in_W, d_out_D, d_out_P);
 
     cudaEventRecord(stop, 0);
     cudaEventSynchronize(stop);
@@ -155,7 +153,6 @@ int runBellmanFordOnGPU(const char *file, int blockSize, int debug) {
     cudaFree(d_out_D);
     cudaFree(d_out_P);
     cudaFree(d_out_Di);
-    cudaFree(d_out_Pi);
     return 0;
 }
 
@@ -198,7 +195,6 @@ int runBellmanFordOnGPUWithGridStride(const char *file, int blocks, int blockSiz
     int *d_out_D; // Final shortest distance
     int *d_out_Di; // Used in keep track of the distance during one single execution of the kernel
     int *d_out_P; // Final parent
-    int *d_out_Pi; // Used in keep track of the parent during one single execution of the kernel
 
     //allocate memory
     cudaMalloc((void**) &d_in_V, V.size() *sizeof(int));
@@ -209,7 +205,6 @@ int runBellmanFordOnGPUWithGridStride(const char *file, int blocks, int blockSiz
     cudaMalloc((void**) &d_out_D, V.size() *sizeof(int));
     cudaMalloc((void**) &d_out_Di, V.size() *sizeof(int));
     cudaMalloc((void**) &d_out_P, V.size() *sizeof(int));
-    cudaMalloc((void**) &d_out_Pi, V.size() *sizeof(int));
 
     //copy to device memory
     cudaMemcpy(d_in_V, V.data(), V.size() *sizeof(int), cudaMemcpyHostToDevice);
@@ -218,9 +213,8 @@ int runBellmanFordOnGPUWithGridStride(const char *file, int blocks, int blockSiz
     cudaMemcpy(d_in_W, W.data(), W.size() *sizeof(int), cudaMemcpyHostToDevice);
 
     initializeArrayWithGridStride<<<BLOCKS, BLOCK_SIZE>>>(V.size(), d_out_D, MAX_VAL, true, 0, 0);
-    initializeArrayWithGridStride<<<BLOCKS, BLOCK_SIZE>>>(V.size(), d_out_P, -1, true, 0, 0);
+    initializeArrayWithGridStride<<<BLOCKS, BLOCK_SIZE>>>(V.size(), d_out_P, MAX_VAL, true, 0, 0);
     initializeArrayWithGridStride<<<BLOCKS, BLOCK_SIZE>>>(V.size(), d_out_Di, MAX_VAL, true, 0, 0);
-    initializeArrayWithGridStride<<<BLOCKS, BLOCK_SIZE>>>(V.size(), d_out_Pi, -1, true, 0, 0);
 
     //Do binary search to find index of each element in E. This won't be necessary if the vertex starts from 0.
     //But in the case of DIMACS vertex start from 1. so in the relax kernel index of the destination vertex is needed to update the D array.
@@ -233,9 +227,10 @@ int runBellmanFordOnGPUWithGridStride(const char *file, int blocks, int blockSiz
         if(DEBUG){
             cout<< "***** round = " << round << " ******* " << endl;
         }
-        relaxWithGridStride<<<BLOCKS, BLOCK_SIZE>>>(N, MAX_VAL, d_in_V, d_in_I, d_in_E, d_in_W, d_out_D, d_out_Di, d_out_P, d_out_Pi);
-        updateDistanceWithGridStride<<<BLOCKS, BLOCK_SIZE>>>(V.size(), d_in_V, d_in_I, d_in_E, d_in_W, d_out_D, d_out_Di, d_out_P, d_out_Pi);
+        relaxWithGridStride<<<BLOCKS, BLOCK_SIZE>>>(N, MAX_VAL, d_in_V, d_in_I, d_in_E, d_in_W, d_out_D, d_out_Di);
+        updateDistanceWithGridStride<<<BLOCKS, BLOCK_SIZE>>>(V.size(), d_in_V, d_in_I, d_in_E, d_in_W, d_out_D, d_out_Di);
     }
+    updatePredWithGridStride<<<BLOCKS, BLOCK_SIZE>>> (V.size(), d_in_V, d_in_I, d_in_E, d_in_W, d_out_D, d_out_P);
 
     cudaEventRecord(stop, 0);
     cudaEventSynchronize(stop);
@@ -278,7 +273,6 @@ int runBellmanFordOnGPUWithGridStride(const char *file, int blocks, int blockSiz
     cudaFree(d_out_D);
     cudaFree(d_out_P);
     cudaFree(d_out_Di);
-    cudaFree(d_out_Pi);
     return 0;
 }
 
@@ -323,7 +317,6 @@ int runBellmanFordOnGPUV3(const char *file, int blocks, int blockSize, int debug
     int *d_out_D; // Final shortest distance
     int *d_out_Di; // Used in keep track of the distance during one single execution of the kernel
     int *d_out_P; // Final parent
-    int *d_out_Pi; // Used in keep track of the parent during one single execution of the kernel
     bool *d_Flag;
 
     //allocate memory
@@ -335,7 +328,6 @@ int runBellmanFordOnGPUV3(const char *file, int blocks, int blockSize, int debug
     cudaMalloc((void**) &d_out_D, V.size() *sizeof(int));
     cudaMalloc((void**) &d_out_Di, V.size() *sizeof(int));
     cudaMalloc((void**) &d_out_P, V.size() *sizeof(int));
-    cudaMalloc((void**) &d_out_Pi, V.size() *sizeof(int));
     cudaMalloc((void**) &d_Flag, V.size() *sizeof(bool));
 
     //copy to device memory
@@ -345,9 +337,8 @@ int runBellmanFordOnGPUV3(const char *file, int blocks, int blockSize, int debug
     cudaMemcpy(d_in_W, W.data(), W.size() *sizeof(int), cudaMemcpyHostToDevice);
 
     initializeArrayWithGridStride<<<BLOCKS, BLOCK_SIZE>>>(V.size(), d_out_D, MAX_VAL, true, 0, 0);
-    initializeArrayWithGridStride<<<BLOCKS, BLOCK_SIZE>>>(V.size(), d_out_P, -1, true, 0, 0);
+    initializeArrayWithGridStride<<<BLOCKS, BLOCK_SIZE>>>(V.size(), d_out_P, MAX_VAL, true, 0, 0);
     initializeArrayWithGridStride<<<BLOCKS, BLOCK_SIZE>>>(V.size(), d_out_Di, MAX_VAL, true, 0, 0);
-    initializeArrayWithGridStride<<<BLOCKS, BLOCK_SIZE>>>(V.size(), d_out_Pi, -1, true, 0, 0);
     initializeBooleanArrayWithGridStride<<<BLOCKS, BLOCK_SIZE>>>(V.size(), d_Flag, false, true, 0, true); // set all elements to false except source which is V[0]
 
     //Do binary search to find index of each element in E. This won't be necessary if the vertex starts from 0.
@@ -361,9 +352,10 @@ int runBellmanFordOnGPUV3(const char *file, int blocks, int blockSize, int debug
         if(DEBUG){
             cout<< "***** round = " << round << " ******* " << endl;
         }
-        relaxWithGridStrideV3<<<BLOCKS, BLOCK_SIZE>>>(N, MAX_VAL, d_in_V, d_in_I, d_in_E, d_in_W, d_out_D, d_out_Di, d_out_P, d_out_Pi, d_Flag);
-        updateDistanceWithGridStrideV3<<<BLOCKS, BLOCK_SIZE>>>(V.size(), d_in_V, d_in_I, d_in_E, d_in_W, d_out_D, d_out_Di, d_out_P, d_out_Pi, d_Flag);
+        relaxWithGridStrideV3<<<BLOCKS, BLOCK_SIZE>>>(N, MAX_VAL, d_in_V, d_in_I, d_in_E, d_in_W, d_out_D, d_out_Di, d_Flag);
+        updateDistanceWithGridStrideV3<<<BLOCKS, BLOCK_SIZE>>>(V.size(), d_in_V, d_in_I, d_in_E, d_in_W, d_out_D, d_out_Di, d_Flag);
     }
+    updatePredWithGridStride<<<BLOCKS, BLOCK_SIZE>>> (V.size(), d_in_V, d_in_I, d_in_E, d_in_W, d_out_D, d_out_P);
 
     cudaEventRecord(stop, 0);
     cudaEventSynchronize(stop);
@@ -406,6 +398,5 @@ int runBellmanFordOnGPUV3(const char *file, int blocks, int blockSize, int debug
     cudaFree(d_out_D);
     cudaFree(d_out_P);
     cudaFree(d_out_Di);
-    cudaFree(d_out_Pi);
     return 0;
 }

--- a/gpu/kernels.cu
+++ b/gpu/kernels.cu
@@ -18,8 +18,8 @@ __global__ void relax(int N, int MAX_VAL, int *d_in_V, int *d_in_I, int *d_in_E,
             }
 
             if (newDist < dv) {
-                atomicExch(&d_out_Di[d_in_E[j]],newDist);
-                atomicExch(&d_out_Pi[d_in_E[j]],u);
+                atomicMin(&d_out_Di[d_in_E[j]],newDist);
+                atomicMin(&d_out_Pi[d_in_E[j]],u);
             }
         }
     }
@@ -48,8 +48,8 @@ __global__ void relaxWithGridStride(int N, int MAX_VAL, int *d_in_V, int *d_in_I
             //printf("Index = %d, w=%d, du =%d, dv=%d,  -- du + w = %d\n", index, w, du , dv, du + w);
 
             if (newDist < dv) {
-                atomicExch(&d_out_Di[d_in_E[j]],newDist);
-                atomicExch(&d_out_Pi[d_in_E[j]],u);
+                atomicMin(&d_out_Di[d_in_E[j]],newDist);
+                atomicMin(&d_out_Pi[d_in_E[j]],u);
             }
         }
     }
@@ -201,8 +201,8 @@ __global__ void relaxWithGridStrideV3(int N, int MAX_VAL, int *d_in_V, int *d_in
                 //printf("Index = %d, w=%d, du =%d, dv=%d,  -- du + w = %d\n", index, w, du , dv, du + w);
 
                 if (newDist < dv) {
-                    atomicExch(&d_out_Di[d_in_E[j]], newDist);
-                    atomicExch(&d_out_Pi[d_in_E[j]], u);
+                    atomicMin(&d_out_Di[d_in_E[j]], newDist);
+                    atomicMin(&d_out_Pi[d_in_E[j]], u);
                 }
             }
         }

--- a/gpu/kernels.cuh
+++ b/gpu/kernels.cuh
@@ -19,19 +19,22 @@ using std::cout;
 using std::endl;
 
 //Kernels for Version 1 - Monolithic kernel for Bellman Ford relax operation
-__global__ void relax(int N, int MAX_VAL, int *d_in_V, int *d_in_I, int *d_in_E, int *d_in_W, int *d_out_D, int *d_out_Di, int *d_out_P,  int *d_out_Pi);
-__global__ void updateDistance(int N, int *d_in_V, int *d_in_I, int *d_in_E, int *d_in_W, int *d_out_D, int *d_out_Di, int *d_out_P,  int *d_out_Pi);
+__global__ void relax(int N, int MAX_VAL, int *d_in_V, int *d_in_I, int *d_in_E, int *d_in_W, int *d_out_D, int *d_out_Di);
+__global__ void updateDistance(int N, int *d_in_V, int *d_in_I, int *d_in_E, int *d_in_W, int *d_out_D, int *d_out_Di);
 __global__ void updateIndexOfEdges(int N, int *d_in_V, int *d_in_E, int l, int r);
+__global__ void updatePred(int N, int *d_in_V, int *d_in_I, int *d_in_E, int *d_in_W, int *d_out_D, int *d_out_P);
 __global__ void initializeArray(const int N, int *p, const int val, bool sourceDifferent, const int source, const int sourceVal);
 
 //Kernels for Version 2 - Kernel with Grid Stride for Bellman Ford relax operation
-__global__ void relaxWithGridStride(int N, int MAX_VAL, int *d_in_V, int *d_in_I, int *d_in_E, int *d_in_W, int *d_out_D, int *d_out_Di, int *d_out_P,  int *d_out_Pi);
-__global__ void updateDistanceWithGridStride(int N, int *d_in_V, int *d_in_I, int *d_in_E, int *d_in_W, int *d_out_D, int *d_out_Di, int *d_out_P,  int *d_out_Pi);
+__global__ void relaxWithGridStride(int N, int MAX_VAL, int *d_in_V, int *d_in_I, int *d_in_E, int *d_in_W, int *d_out_D, int *d_out_Di);
+__global__ void updateDistanceWithGridStride(int N, int *d_in_V, int *d_in_I, int *d_in_E, int *d_in_W, int *d_out_D, int *d_out_Di);
 __global__ void updateIndexOfEdgesWithGridStide(int N, int *d_in_V, int *d_in_E, int l, int r);
 __global__ void initializeArrayWithGridStride(const int N, int *p, const int val, bool sourceDifferent, const int source, const int sourceVal);
 
 //Kernels for Version 3 - Kernel with Grid Stride and boolean array to perform relax operation only if the source vertex has a lesser distance than the previous iteration
 __global__ void initializeBooleanArrayWithGridStride(const int N, bool *p, const int val, bool sourceDifferent, const int source, const bool sourceVal);
-__global__ void relaxWithGridStrideV3(int N, int MAX_VAL, int *d_in_V, int *d_in_I, int *d_in_E, int *d_in_W, int *d_out_D, int *d_out_Di, int *d_out_P,  int *d_out_Pi, bool *p_Flag);
-__global__ void updateDistanceWithGridStrideV3(int N, int *d_in_V, int *d_in_I, int *d_in_E, int *d_in_W, int *d_out_D, int *d_out_Di, int *d_out_P, int *d_out_Pi, bool *p_Flag);
+__global__ void relaxWithGridStrideV3(int N, int MAX_VAL, int *d_in_V, int *d_in_I, int *d_in_E, int *d_in_W, int *d_out_D, int *d_out_Di, bool *p_Flag);
+__global__ void updateDistanceWithGridStrideV3(int N, int *d_in_V, int *d_in_I, int *d_in_E, int *d_in_W, int *d_out_D, int *d_out_Di, bool *p_Flag);
+__global__ void updatePredWithGridStride(int N, int *d_in_V, int *d_in_I, int *d_in_E, int *d_in_W, int *d_out_D, int *d_out_P);
+
 #endif //GPU_GRAPH_ALGORITHMS_KERNELS_CUH

--- a/main.cpp
+++ b/main.cpp
@@ -5,6 +5,7 @@ int main(int argc, char **argv) {
         cout << "Usage : ./bellman MODE FILE BLOCK_SIZE DEBUG" << endl;
         cout << "MODE - seq / cuda \n"
                 "FILE - Input file \n"
+                "BLOCKS - Number of blocks per grid for cuda\n"
                 "BLOCK_SIZE - Number of threads per block for cuda \n"
                 "DEBUG - 1 or 0 to enable/disable extended debug messages on console\n"
                 "Program expects these CSV files based on FILE thats passed in the argument\n"
@@ -17,9 +18,6 @@ int main(int argc, char **argv) {
     }
     std::string mode = argv[1];
     std::string file;
-    int debug;
-    int BLOCK_SIZE;
-    int BLOCKS;
     if(argv[2] != NULL){
         file = argv[2];
         //Check if all CSR files are present
@@ -32,19 +30,10 @@ int main(int argc, char **argv) {
         }
 
     }
-    if(argv[3] != NULL){
-        BLOCKS = atoi(argv[3]);
-    }
-    if(argv[4] != NULL){
-        BLOCK_SIZE = atoi(argv[4]);
-    }
-    if(argv[5] != NULL){
-        debug = atoi(argv[5]);
-    }
 
-    (BLOCKS == 0) ? 4 : BLOCKS; // Set default to 4 blocks
-    (BLOCK_SIZE == 0) ? 512 : BLOCK_SIZE; // Set default to 512 threads
-    (debug == 0) ? 0 : 1;
+    int BLOCKS = argc > 3 ? atoi(argv[3]) : 4;
+    int BLOCK_SIZE = argc > 4 ? atoi(argv[4]) : 512;
+    int debug = argc > 5 ? atoi(argv[5]) : 0;
 
     if(mode == "seq") {
         // Reference https://www.geeksforgeeks.org/measure-execution-time-function-cpp/


### PR DESCRIPTION
## default value of the variable is not correct.

![Snipaste_2021-01-24_17-59-17](https://user-images.githubusercontent.com/36565277/105627208-5af0a300-5e70-11eb-8ffa-e3e7e29e307b.jpg)


## The problem with atomicExch


When I ran the code, I found that the results of the two cuda versions (cuda-stride & cuda-v3) were different.

![Snipaste_2021-01-24_18-32-35](https://user-images.githubusercontent.com/36565277/105627921-9beab680-5e74-11eb-9eca-bdaeec6a6c7d.jpg)


I think the reason is that there may be multiple threads that meet the if condition at the same time. They will all use atomicExch to exchange the value to `d_out_Di[]`. At this time, some threads may override the minimum value.

https://github.com/sengorajkumar/gpu_graph_algorithms/blob/983ba47db7411bf012af2848bd9ffa6336e9a94f/gpu/kernels.cu#L203-L206

Use the `atomicMin` function can solve this problem.

https://github.com/Sanzona/gpu_graph_algorithms/blob/3b4395af5bd090687d735189bfa4df5a2d0a9354/gpu/kernels.cu#L204

